### PR TITLE
Fix undefined array key warning in TokenAuthenticationService

### DIFF
--- a/Classes/Authentication/TokenAuthenticationService.php
+++ b/Classes/Authentication/TokenAuthenticationService.php
@@ -73,7 +73,10 @@ class TokenAuthenticationService extends AbstractAuthenticationService
         if (isset($_POST[$parameterName])) {
             return trim((string)($_POST[$parameterName]));
         }
-        return trim((string)($_GET[$parameterName]));
+        if (isset($_POST[$parameterName])) {
+            return trim((string)($_GET[$parameterName]));
+        }
+        return null;
     }
 
 }

--- a/Classes/Authentication/TokenAuthenticationService.php
+++ b/Classes/Authentication/TokenAuthenticationService.php
@@ -73,7 +73,7 @@ class TokenAuthenticationService extends AbstractAuthenticationService
         if (isset($_POST[$parameterName])) {
             return trim((string)($_POST[$parameterName]));
         }
-        if (isset($_POST[$parameterName])) {
+        if (isset($_GET[$parameterName])) {
             return trim((string)($_GET[$parameterName]));
         }
         return null;


### PR DESCRIPTION
[WARNING] request="99e57da6573ed" component="TYPO3.CMS.Core.Error.ErrorHandler": Core: Error handler (BE): PHP Warning: Undefined array key "msblToken" in /var/www/html/app/public/typo3conf/ext/multisite_belogin/Classes/Authentication/TokenAuthenticationService.php line 76